### PR TITLE
Update rc522.c to not output init message

### DIFF
--- a/src/rc522.c
+++ b/src/rc522.c
@@ -9,7 +9,6 @@ uint8_t debug = 0;
 
 void InitRc522(void)
 {
-	printf("InitRc522");
 	PcdReset();
 	PcdAntennaOn();
 }


### PR DESCRIPTION
Do not output init message to avoid init message as scanned id output